### PR TITLE
GitHub Actions workflow for building and releasing a Spring Boot project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: SonarCloud and Deploy to AWS
+name: Spring Boot Build and Release
 
 on:
   push:
@@ -9,22 +9,26 @@ on:
 
 jobs:
   build:
-    name: Build, analyze and deploy
+    name: Build and Release
     runs-on: ubuntu-latest
-    steps:
-      # Checkout the repository
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for better relevancy of analysis
+    permissions:
+      contents: write  # Ensure the token has permission to write releases
 
-      # Set up JDK 17
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch all history for SonarCloud analysis
+
+      # Step 2: Set up JDK 17 for Spring Boot
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu' # Alternative distribution options are available.
+          distribution: 'zulu'  # You can change this to any distribution you prefer
 
-      # Cache SonarCloud packages
+      # Step 3: Cache SonarCloud packages (optional, if using SonarCloud)
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -32,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      # Cache Maven packages
+      # Step 4: Cache Maven packages for faster builds
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:
@@ -40,38 +44,29 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      # Build and analyze with SonarCloud
-      - name: Build and analyze
-        working-directory: pos-system
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dsonar.projectKey=Life-Pill_pharmacy-pos-backend
+      # Step 5: Build and analyze the code with Maven
+      - name: Build and analyze the Spring Boot project
+        working-directory: pos-system  # Adjust if your backend is in a subdirectory
+        run: mvn -B clean verify -DskipTests
 
-      # Create a new GitHub release
-      - name: Create Release
+      # Step 6: Create a new GitHub release
+      - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ github.sha }}
-          release_name: Release ${{ github.sha }}
+          tag_name: v${{ github.sha }}  # Use commit SHA as the tag name
+          release_name: "Release ${{ github.sha }}"  # Use commit SHA as the release name
           draft: false
           prerelease: false
           body: "Automated release created by GitHub Actions"
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_2 }}  # Using the renamed token 'TOKEN_2'
 
-      # Deploy to AWS EC2
-      - name: Deploy to AWS EC2
-        uses: appleboy/ssh-action@master
+      # Step 7: Upload build artifacts to the release
+      - name: Upload Artifact to Release
+        uses: actions/upload-release-asset@v1
         with:
-          host: ${{ secrets.AWS_EC2_HOST }}
-          username: ${{ secrets.AWS_EC2_USER }}
-          key: ${{ secrets.AWS_EC2_KEY }}
-          port: 22
-          script: |
-            cd /path/to/your/app/on/ec2
-            sudo systemctl stop my-spring-app
-            rm -rf *
-            scp /path/to/generated/jar/from/github myapp.jar
-            sudo systemctl start my-spring-app
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/*.jar  # Adjust the path to the artifact you want to upload
+          asset_name: your-springboot-app.jar  # Name the uploaded file
+          asset_content_type: application/java-archive


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and releasing a Spring Boot project. The changes improve the clarity of the workflow steps, add necessary permissions, and modify the release process. The most important changes include renaming the workflow, adding permissions for writing releases, and updating the build and release steps.

Workflow improvements:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L1-R1): Renamed the workflow from "SonarCloud and Deploy to AWS" to "Spring Boot Build and Release" to better reflect its purpose.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L12-R72): Added `contents: write` permission to ensure the token can write releases.

Build and release process updates:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L12-R72): Updated step names for better clarity and added comments to describe each step in the build process.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L12-R72): Changed the GitHub release step to use a renamed token `TOKEN_2` and updated the release name and tag to use the commit SHA.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L12-R72): Replaced the AWS EC2 deployment step with a step to upload build artifacts to the release.