### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,12 +49,6 @@ jobs:
         working-directory: pos-system  # Adjust if your backend is in a subdirectory
         run: mvn -B clean verify -DskipTests
 
-      # Step 6: Deploy to AWS EC2 instance (replace with your deployment logic)
-      - name: Deploy to AWS EC2
-        run: |
-          scp -i /path/to/your/key.pem target/*.jar ec2-user@${{ secrets.AWS_EC2_HOST }}:/path/to/deploy
-          ssh -i /path/to/your/key.pem ec2-user@${{ secrets.AWS_EC2_HOST }} "sudo systemctl restart your-springboot-service"
-
       # Step 7: Create a new GitHub release
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
This pull request to the `.github/workflows/build.yaml` file removes the step for deploying to an AWS EC2 instance, simplifying the workflow. The most important change is the removal of the AWS EC2 deployment step.

Simplification of workflow:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L52-L57): Removed the step for deploying to an AWS EC2 instance, including commands for copying the JAR file and restarting the service.