### PR TITLE
Maintain consistency across the codebase.

### DIFF
--- a/pos-system/src/main/java/com/lifepill/possystem/service/impl/OrderServiceIMPL.java
+++ b/pos-system/src/main/java/com/lifepill/possystem/service/impl/OrderServiceIMPL.java
@@ -438,6 +438,4 @@ public class OrderServiceIMPL implements OrderService {
                 })
                 .collect(Collectors.toList());
     }
-
-
 }

--- a/pos-system/src/main/java/com/lifepill/possystem/util/mappers/EmployerMapper.java
+++ b/pos-system/src/main/java/com/lifepill/possystem/util/mappers/EmployerMapper.java
@@ -6,8 +6,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class EmployerMapper {
-
-
     public EmployerBankDetails mapBankDetailsDTOToEntity(EmployerBankDetailsDTO bankDetailsDTO) {
         if (bankDetailsDTO == null) {
             return null;
@@ -24,5 +22,4 @@ public class EmployerMapper {
       //  employerBankDetails.setEmployers(bankDetailsDTO.getEmployers());
         return employerBankDetails;
     }
-
 }

--- a/pos-system/src/main/java/com/lifepill/possystem/util/mappers/ItemMapper.java
+++ b/pos-system/src/main/java/com/lifepill/possystem/util/mappers/ItemMapper.java
@@ -12,10 +12,7 @@ import java.util.List;
 public interface ItemMapper {
     // itemList ----> ItemResponseDTO
     List<ItemGetResponseDTO> entityListToDTOList(List<Item> items);
-
     List<ItemGetAllResponseDTO> entityListAllItemToDTO(List<Item> items);
-
     //Page<Item> items ---> List<ItemGetResponseDTO> list;
     List<ItemGetResponseDTO>ListDTOToPage(Page<Item> items);
-
 }

--- a/pos-system/src/main/java/com/lifepill/possystem/util/mappers/OrderMapper.java
+++ b/pos-system/src/main/java/com/lifepill/possystem/util/mappers/OrderMapper.java
@@ -48,9 +48,7 @@ public class OrderMapper {
             paymentDetailsDTO.setPayedAmount(paymentDetails.getPaidAmount());
             groupedOrderDetails.setPaymentDetails(paymentDetailsDTO);
         }
-
         groupedOrderDetails.setOrderCount(1); // Since we're retrieving a single order
-
         orderResponseDTO.setGroupedOrderDetails(groupedOrderDetails);
         return orderResponseDTO;
     }


### PR DESCRIPTION
This pull request includes several minor clean-up changes to remove unnecessary blank lines in various mapper classes and service implementations. These changes help to improve code readability and maintain consistency across the codebase.

Code readability improvements:

* [`pos-system/src/main/java/com/lifepill/possystem/service/impl/OrderServiceIMPL.java`](diffhunk://#diff-ed1f3265baab58f25ff62e6b0920b94952cb27f869243e791752be48bc8b3ca1L441-L442): Removed unnecessary blank lines at the end of the `getOrderWithDetailsByBranchId` method.
* [`pos-system/src/main/java/com/lifepill/possystem/util/mappers/EmployerMapper.java`](diffhunk://#diff-81b4fa4d39373f7fa2f8859d8bcc142610ce91ea795475468d0740845fc5cabcL9-L10): Removed unnecessary blank lines in the `EmployerMapper` class. [[1]](diffhunk://#diff-81b4fa4d39373f7fa2f8859d8bcc142610ce91ea795475468d0740845fc5cabcL9-L10) [[2]](diffhunk://#diff-81b4fa4d39373f7fa2f8859d8bcc142610ce91ea795475468d0740845fc5cabcL27)
* [`pos-system/src/main/java/com/lifepill/possystem/util/mappers/ItemMapper.java`](diffhunk://#diff-e194732e32271670d946b18d82079950ca43bd2e3d3dbd4b356b21479c49aadeL15-L20): Removed unnecessary blank lines in the `ItemMapper` interface.
* [`pos-system/src/main/java/com/lifepill/possystem/util/mappers/OrderMapper.java`](diffhunk://#diff-5403e6c6637a90495fd572b5a1f37aa06cb5d2aef03e6e316a686fb89ef411cbL51-L53): Removed unnecessary blank lines in the `mapOrderToResponseDTO` method.