### PR TITLE
The Update the step for uploading build artifacts to the release. 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,12 +61,3 @@ jobs:
           body: "Automated release created by GitHub Actions"
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_2 }}  # Using the renamed token 'TOKEN_2'
-
-      # Step 8: Upload build artifacts to the release
-      - name: Upload Artifact to Release
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/*.jar  # Adjust the path to the artifact you want to upload
-          asset_name: your-springboot-app.jar  # Name the uploaded file
-          asset_content_type: application/java-archive


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yaml` file. The change removes the step for uploading build artifacts to the release. 

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L64-L72): Removed the step for uploading build artifacts to the release.